### PR TITLE
Fix GraphQL global exceptions filter

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,8 @@ import { NestFactory } from '@nestjs/core';
 
 import { AppModule } from './app.module';
 import { VALIDATION_PIPE_OPTIONS } from './shared/constants';
+import { AllExceptionsFilter } from './shared/filters/all-exceptions.filter';
+import { AppLogger } from './shared/logger/logger.service';
 import { RequestIdMiddleware } from './shared/middlewares/request-id/request-id.middleware';
 
 async function bootstrap() {
@@ -15,6 +17,7 @@ async function bootstrap() {
   app.enableCors();
 
   const configService = app.get(ConfigService);
+  app.useGlobalFilters(new AllExceptionsFilter(configService, new AppLogger()));
   const port = configService.get<number>('port');
   await app.listen(port);
 }

--- a/src/shared/filters/all-exceptions.filter.spec.ts
+++ b/src/shared/filters/all-exceptions.filter.spec.ts
@@ -50,6 +50,7 @@ describe('AllExceptionsFilter', () => {
         url: 'mock-url',
         headers: [],
         header: jest.fn(),
+        body: jest.fn(),
         res: mockResponse,
       },
     };

--- a/src/shared/filters/all-exceptions.filter.spec.ts
+++ b/src/shared/filters/all-exceptions.filter.spec.ts
@@ -50,7 +50,6 @@ describe('AllExceptionsFilter', () => {
         url: 'mock-url',
         headers: [],
         header: jest.fn(),
-        body: jest.fn(),
         res: mockResponse,
       },
     };
@@ -187,6 +186,17 @@ describe('AllExceptionsFilter', () => {
       expect.objectContaining({
         error: expect.objectContaining({
           requestId: mockRequest.req.headers[REQUEST_ID_TOKEN_HEADER],
+        }),
+      }),
+    );
+  });
+
+  it('should contain request path in response', async () => {
+    filter.catch(mockMessage1, mockContext);
+    expect(mockResponse.json).toBeCalledWith(
+      expect.objectContaining({
+        error: expect.objectContaining({
+          path: mockRequest.req.url,
         }),
       }),
     );

--- a/src/shared/filters/all-exceptions.filter.ts
+++ b/src/shared/filters/all-exceptions.filter.ts
@@ -24,10 +24,21 @@ export class AllExceptionsFilter<T> implements GqlExceptionFilter {
   }
 
   catch(exception: T, host: ArgumentsHost): any {
-    const ctx = GqlArgumentsHost.create(host).getContext();
-    const req = <Request>ctx.req;
-    const res = <Response>ctx.req.res;
+    let ctx;
+    let req: Request;
+    let res: Response;
 
+    if (host.getType() == 'http') {
+      ctx = host.switchToHttp();
+      req = ctx.getRequest();
+      res = ctx.getResponse();
+    } else {
+      ctx = GqlArgumentsHost.create(host).getContext();
+      req = <Request>ctx.req;
+      res = <Response>ctx.req.res;
+    }
+
+    const query = req.body.query;
     const timestamp = new Date().toISOString();
     const requestId = req.headers[REQUEST_ID_TOKEN_HEADER];
     const requestContext = createRequestContext(req);
@@ -72,6 +83,7 @@ export class AllExceptionsFilter<T> implements GqlExceptionFilter {
       errorName,
       details,
       // Additional meta added by us.
+      query,
       requestId,
       timestamp,
     };

--- a/src/shared/filters/all-exceptions.filter.ts
+++ b/src/shared/filters/all-exceptions.filter.ts
@@ -38,7 +38,7 @@ export class AllExceptionsFilter<T> implements GqlExceptionFilter {
       res = <Response>ctx.req.res;
     }
 
-    const query = req.body.query;
+    const path = req.url;
     const timestamp = new Date().toISOString();
     const requestId = req.headers[REQUEST_ID_TOKEN_HEADER];
     const requestContext = createRequestContext(req);
@@ -83,7 +83,7 @@ export class AllExceptionsFilter<T> implements GqlExceptionFilter {
       errorName,
       details,
       // Additional meta added by us.
-      query,
+      path,
       requestId,
       timestamp,
     };


### PR DESCRIPTION
- Fix all exceptions filter to support catching the errors thrown by GraphQL
- Change the unit test accordingly.

## Filter off:
```
{
    "errors": [
        {
            "message": "Fake forced exception.",
            "extensions": {
                "code": "UNAUTHENTICATED",
                "response": {
                    "statusCode": 401,
                    "message": "Fake forced exception.",
                    "error": "Unauthorized"
                }
            }
        }
    ],
    "data": null
}
```

## Filter on:
```
{
    "error": {
        "statusCode": 401,
        "message": "Fake forced exception.",
        "errorName": "UnauthorizedException",
        "details": {
            "statusCode": 401,
            "message": "Fake forced exception.",
            "error": "Unauthorized"
        },
        "requestId": "450b0a73-0901-4f13-8b23-9cadd651c342",
        "timestamp": "2022-01-13T13:32:34.304Z"
    }
}
```